### PR TITLE
Create variants and variant images alongside product

### DIFF
--- a/src/__tests__/components/DragDropImageUploader.test.tsx
+++ b/src/__tests__/components/DragDropImageUploader.test.tsx
@@ -66,4 +66,16 @@ describe("DragDropImageUploader", () => {
       })
     );
   });
+
+  it('should show loading state when "isLoading" is true', () => {
+    const { queryByTestId } = render(
+      <DragDropImageUploader
+        onFileSelect={vi.fn()}
+        onDropFile={vi.fn()}
+        isLoading
+      />
+    );
+
+    expect(queryByTestId(DRAG_DROP_SELECTORS.loading)).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components/NewVariantCard.test.tsx
+++ b/src/__tests__/components/NewVariantCard.test.tsx
@@ -1,4 +1,7 @@
+import React from "react";
 import { render, fireEvent } from "@testing-library/react";
+import SnackbarProvider from "react-simple-snackbar";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import {
   NEW_VARIANT_CARD_ITEM,
   VARIANT_SELECTORS,
@@ -7,18 +10,36 @@ import {
   SLIDER_IMAGE_CARD,
 } from "helpers/test";
 import { es } from "helpers/strings";
+import { ROUTES } from "helpers/constants";
 import NewVariantCard from "components/NewVariantCard";
 
 describe("NewVariantCard", () => {
   const mockSetVariants = vi.fn();
 
   it("renders initial components", () => {
+    const routes = [
+      {
+        path: ROUTES.NEW_PRODUCT,
+        element: (
+          <NewVariantCard
+            variant={{ ...NEW_VARIANT_CARD_ITEM, images: [] }}
+            index={0}
+            setVariants={mockSetVariants}
+          />
+        ),
+        action: () => true,
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [ROUTES.NEW_PRODUCT],
+    });
+
     const { getByTestId } = render(
-      <NewVariantCard
-        variant={{ ...NEW_VARIANT_CARD_ITEM, images: [] }}
-        index={0}
-        setVariants={mockSetVariants}
-      />
+      <React.StrictMode>
+        <SnackbarProvider>
+          <RouterProvider router={router} />
+        </SnackbarProvider>
+      </React.StrictMode>
     );
 
     const titleInput = getByTestId(VARIANT_SELECTORS.newName);
@@ -49,12 +70,28 @@ describe("NewVariantCard", () => {
   });
 
   it("shows correct elements when it has images", () => {
+    const routes = [
+      {
+        path: ROUTES.NEW_PRODUCT,
+        element: (
+          <NewVariantCard
+            variant={NEW_VARIANT_CARD_ITEM}
+            index={0}
+            setVariants={mockSetVariants}
+          />
+        ),
+        action: () => true,
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [ROUTES.NEW_PRODUCT],
+    });
     const { getByTestId, queryByTestId } = render(
-      <NewVariantCard
-        variant={NEW_VARIANT_CARD_ITEM}
-        index={0}
-        setVariants={mockSetVariants}
-      />
+      <React.StrictMode>
+        <SnackbarProvider>
+          <RouterProvider router={router} />
+        </SnackbarProvider>
+      </React.StrictMode>
     );
 
     const titleInput = getByTestId(VARIANT_SELECTORS.newName);
@@ -81,12 +118,29 @@ describe("NewVariantCard", () => {
   });
 
   it("updates the variant title when input value changes", () => {
+    const routes = [
+      {
+        path: ROUTES.NEW_PRODUCT,
+        element: (
+          <NewVariantCard
+            variant={NEW_VARIANT_CARD_ITEM}
+            index={0}
+            setVariants={mockSetVariants}
+          />
+        ),
+        action: () => true,
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [ROUTES.NEW_PRODUCT],
+    });
+
     const { getByTestId } = render(
-      <NewVariantCard
-        variant={NEW_VARIANT_CARD_ITEM}
-        index={0}
-        setVariants={mockSetVariants}
-      />
+      <React.StrictMode>
+        <SnackbarProvider>
+          <RouterProvider router={router} />
+        </SnackbarProvider>
+      </React.StrictMode>
     );
 
     const titleInput = getByTestId(VARIANT_SELECTORS.newName);
@@ -98,12 +152,29 @@ describe("NewVariantCard", () => {
   });
 
   it("updates the variant quantity when input value changes", () => {
+    const routes = [
+      {
+        path: ROUTES.NEW_PRODUCT,
+        element: (
+          <NewVariantCard
+            variant={NEW_VARIANT_CARD_ITEM}
+            index={0}
+            setVariants={mockSetVariants}
+          />
+        ),
+        action: () => true,
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [ROUTES.NEW_PRODUCT],
+    });
+
     const { getByTestId } = render(
-      <NewVariantCard
-        variant={NEW_VARIANT_CARD_ITEM}
-        index={0}
-        setVariants={mockSetVariants}
-      />
+      <React.StrictMode>
+        <SnackbarProvider>
+          <RouterProvider router={router} />
+        </SnackbarProvider>
+      </React.StrictMode>
     );
 
     const quantityInput = getByTestId(VARIANT_SELECTORS.newQuantity);
@@ -115,12 +186,29 @@ describe("NewVariantCard", () => {
   });
 
   it("shows only integers legend when quantity input is a fraction", async () => {
+    const routes = [
+      {
+        path: ROUTES.NEW_PRODUCT,
+        element: (
+          <NewVariantCard
+            variant={{ ...NEW_VARIANT_CARD_ITEM, quantity: "10.5" }}
+            index={0}
+            setVariants={mockSetVariants}
+          />
+        ),
+        action: () => true,
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [ROUTES.NEW_PRODUCT],
+    });
+
     const { getByText } = render(
-      <NewVariantCard
-        variant={{ ...NEW_VARIANT_CARD_ITEM, quantity: "10.5" }}
-        index={0}
-        setVariants={mockSetVariants}
-      />
+      <React.StrictMode>
+        <SnackbarProvider>
+          <RouterProvider router={router} />
+        </SnackbarProvider>
+      </React.StrictMode>
     );
 
     expect(getByText(es.variants.onlyIntegers)).toBeInTheDocument();

--- a/src/__tests__/components/NewVariantCard.test.tsx
+++ b/src/__tests__/components/NewVariantCard.test.tsx
@@ -113,4 +113,16 @@ describe("NewVariantCard", () => {
 
     expect(mockSetVariants).toHaveBeenCalled();
   });
+
+  it("shows only integers legend when quantity input is a fraction", async () => {
+    const { getByText } = render(
+      <NewVariantCard
+        variant={{ ...NEW_VARIANT_CARD_ITEM, quantity: "10.5" }}
+        index={0}
+        setVariants={mockSetVariants}
+      />
+    );
+
+    expect(getByText(es.variants.onlyIntegers)).toBeInTheDocument();
+  });
 });

--- a/src/components/DragDropImageUploader.tsx
+++ b/src/components/DragDropImageUploader.tsx
@@ -1,13 +1,16 @@
 import { DragEvent, ChangeEvent } from "react";
+import { DRAG_DROP_SELECTORS } from "helpers/test";
 import { es } from "helpers/strings";
 
 type Props = {
   onFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
   onDropFile: (event: DragEvent<HTMLDivElement>) => void;
+  isLoading?: boolean;
 };
 export default function DragDropImageUploader({
   onFileSelect,
   onDropFile,
+  isLoading = false,
 }: Props) {
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -25,10 +28,13 @@ export default function DragDropImageUploader({
         "text-gray-500 dark:text-gray-400 " +
         "rounded-md"
       }
-      data-testid="drop-zone"
+      data-testid={DRAG_DROP_SELECTORS.dropZone}
     >
       <i className="fa-solid fa-download text-xl" />
-      <label className="font-bold" data-testid="browse-images">
+      <label
+        className="font-bold"
+        data-testid={DRAG_DROP_SELECTORS.browseImages}
+      >
         {es.variants.browseImages}
         <input
           className="opacity-0 w-0 h-0 absolute -top-1"
@@ -40,6 +46,12 @@ export default function DragDropImageUploader({
         />
       </label>
       <p>{es.variants.dragImages}</p>
+      {isLoading && (
+        <i
+          className={"fa-solid fa-spinner " + "animate-spin mr-2 "}
+          data-testid={DRAG_DROP_SELECTORS.loading}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/NewVariantCard.tsx
+++ b/src/components/NewVariantCard.tsx
@@ -113,6 +113,13 @@ export default function NewVariantCard({ variant, index, setVariants }: Props) {
             value={variant.quantity}
             onChange={handleOnChange}
             labelClassName="font-semibold"
+            otherElements={
+              variant.quantity.includes(".") ? (
+                <p className={"text-red-900 " + "text-sm pl-2"}>
+                  {es.variants.onlyIntegers}
+                </p>
+              ) : undefined
+            }
           />
         </Fragment>
       }

--- a/src/components/NewVariantCard.tsx
+++ b/src/components/NewVariantCard.tsx
@@ -1,4 +1,6 @@
-import { DragEvent, ChangeEvent, MouseEvent, Fragment } from "react";
+import { DragEvent, ChangeEvent, MouseEvent, Fragment, useState } from "react";
+import imageCompression from "browser-image-compression";
+import { useSnackbar } from "react-simple-snackbar";
 import { es } from "helpers/strings";
 import { NewVariantType } from "helpers/customTypes";
 import { VARIANT_SELECTORS } from "helpers/test";
@@ -16,44 +18,33 @@ type Props = {
 };
 
 export default function NewVariantCard({ variant, index, setVariants }: Props) {
-  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
+  const [openSnackbar] = useSnackbar();
+  const [loading, setLoading] = useState(false);
+
+  const options = {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  };
+
+  const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
     event.preventDefault();
     const previews: NewVariantType["images"] = [];
     const files = event.target.files;
+    setLoading(true);
 
     if (files) {
       for (let i = 0; i < files.length; i++) {
-        previews.push({
-          id: i,
-          src: URL.createObjectURL(files[i]),
-          name: files[i].name,
-          file: files[i],
-        });
-      }
-    }
-    setVariants((prev) =>
-      prev.map((item, i) =>
-        i === index ? { ...item, images: previews } : item
-      )
-    );
-  };
-
-  const handleDropFile = (event: DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    const previews: NewVariantType["images"] = [];
-    const items = event.dataTransfer.items;
-
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      if (item.kind === "file") {
-        const file = item.getAsFile();
-        if (file) {
+        try {
+          const compressedFile = await imageCompression(files[i], options);
           previews.push({
             id: i,
-            src: URL.createObjectURL(file),
-            name: file.name,
-            file,
+            src: URL.createObjectURL(files[i]),
+            name: files[i].name,
+            file: compressedFile,
           });
+        } catch (error) {
+          openSnackbar(error);
         }
       }
     }
@@ -62,6 +53,37 @@ export default function NewVariantCard({ variant, index, setVariants }: Props) {
         i === index ? { ...item, images: previews } : item
       )
     );
+    setLoading(false);
+  };
+
+  const handleDropFile = async (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const previews: NewVariantType["images"] = [];
+    const items = event.dataTransfer.files;
+    setLoading(true);
+
+    for (let i = 0; i < items.length; i++) {
+      const file = items[i];
+      if (file) {
+        try {
+          const compressedFile = await imageCompression(file, options);
+          previews.push({
+            id: i,
+            src: URL.createObjectURL(file),
+            name: file.name,
+            file: compressedFile,
+          });
+        } catch (error) {
+          openSnackbar(error);
+        }
+      }
+    }
+    setVariants((prev) =>
+      prev.map((item, i) =>
+        i === index ? { ...item, images: previews } : item
+      )
+    );
+    setLoading(false);
   };
 
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -101,6 +123,7 @@ export default function NewVariantCard({ variant, index, setVariants }: Props) {
               className="w-full text-center text-white"
               labelProps={{ className: "w-full dark:bg-slate-800 my-2" }}
               onFileSelect={handleFileSelect}
+              isLoading={loading}
             />
           )}
           <Input
@@ -130,6 +153,7 @@ export default function NewVariantCard({ variant, index, setVariants }: Props) {
         <DragDropImageUploader
           onFileSelect={handleFileSelect}
           onDropFile={handleDropFile}
+          isLoading={loading}
         />
       )}
       {variant.images.length > 0 && (

--- a/src/helpers/test.ts
+++ b/src/helpers/test.ts
@@ -281,4 +281,5 @@ export const ORDER_SELECTORS = {
 export const DRAG_DROP_SELECTORS = {
   dropZone: "drop-zone",
   browseImages: "browse-images",
+  loading: "loading-spinner",
 };

--- a/src/routes/NewProduct/NewProductView.tsx
+++ b/src/routes/NewProduct/NewProductView.tsx
@@ -92,7 +92,13 @@ export default function ProductDetails() {
     formData.append("price", newProduct.price);
     formData.append("wholesalePrice", newProduct.wholesalePrice);
     formData.append("description", newProduct.description);
-    submit(formData, { method: "post" });
+    formData.append("variants", JSON.stringify(variants)); // TODO: Separate images
+    for (let i = 0; i < variants.length; i++) {
+      for (const image of variants[i].images) {
+        formData.append(`images${i}[]`, image.file, image.name);
+      }
+    }
+    submit(formData, { method: "post", encType: "multipart/form-data" });
   };
 
   return (

--- a/src/routes/NewProduct/NewProductView.tsx
+++ b/src/routes/NewProduct/NewProductView.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useLayoutEffect, useState, ChangeEvent } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useState,
+  ChangeEvent,
+  useMemo,
+} from "react";
 import classnames from "classnames";
 import {
   useActionData,
@@ -34,6 +40,25 @@ export default function ProductDetails() {
     description: "",
   });
   const [variants, setVariants] = useState<NewVariantType[]>([]);
+  const disableSave = useMemo(() => {
+    const hasEmptyVariants = variants.some((variant) => {
+      if (
+        !variant.name ||
+        !variant.quantity ||
+        variant.quantity.includes(".") ||
+        !variant.images.length
+      ) {
+        return true;
+      }
+    });
+    return (
+      !newProduct.name ||
+      newProduct.price === "" ||
+      newProduct.wholesalePrice === "" ||
+      !newProduct.description ||
+      hasEmptyVariants
+    );
+  }, [newProduct, variants]);
 
   useEffect(() => {
     if (actionData?.message) {
@@ -121,12 +146,7 @@ export default function ProductDetails() {
         <Button
           data-testid="new-product-save"
           onClick={handleSave}
-          disabled={
-            !newProduct.name ||
-            newProduct.price === "" ||
-            newProduct.wholesalePrice === "" ||
-            !newProduct.description
-          }
+          disabled={disableSave}
         >
           {es.save}
         </Button>

--- a/src/routes/NewProduct/actions.ts
+++ b/src/routes/NewProduct/actions.ts
@@ -1,6 +1,8 @@
 import { ActionFunctionArgs, redirect } from "react-router-dom";
 import { postProduct } from "routes/Products/api";
+import { postVariant, postVariantImages } from "routes/Variants/api";
 import { ROUTES } from "helpers/constants";
+import { VariantBase } from "helpers/customTypes";
 
 export const newProductActions = async ({ request }: ActionFunctionArgs) => {
   const formData = await request.formData();
@@ -15,6 +17,7 @@ export const newProductActions = async ({ request }: ActionFunctionArgs) => {
 
 const handleCreateProduct = async (form: FormData) => {
   const formData = Object.fromEntries(form);
+  const variants = JSON.parse(formData.variants as string) as VariantBase[];
 
   const { data: response, status } = await postProduct({
     name: formData.name as string,
@@ -26,6 +29,52 @@ const handleCreateProduct = async (form: FormData) => {
   if (status !== 200) {
     return response.errors ? response.errors[0] : response;
   } else {
+    for (let i = 0; i < variants.length; i++) {
+      const images = form.getAll(`images${i}[]`);
+      const { error: variantError, id: variantId } = await handleCreateVariants(
+        variants[i],
+        response.id
+      );
+      if (variantError) {
+        return variantError;
+      }
+      const imagesError = await handleCreateVariantImages(
+        variantId,
+        images as File[]
+      );
+      if (imagesError) {
+        return imagesError;
+      }
+    }
     return redirect(ROUTES.DASHBOARD);
+  }
+};
+
+const handleCreateVariants = async (
+  variant: VariantBase,
+  productId: string
+) => {
+  const response = { error: "", id: "" };
+  const { data, status } = await postVariant({
+    newVariantData: { ...variant, quantity: Number(variant.quantity) },
+    productId,
+  });
+  if (status !== 200) {
+    response.error = data.errors ? data.errors[0] : data;
+  }
+  response.id = data.id;
+  return response;
+};
+
+const handleCreateVariantImages = async (variantId: string, images: File[]) => {
+  const formData = new FormData();
+
+  for (const image of images) {
+    formData.append("images[]", image, image.name);
+  }
+
+  const { data, status } = await postVariantImages({ variantId, formData });
+  if (status !== 200) {
+    return data.errors ? data.errors[0] : data;
   }
 };


### PR DESCRIPTION
Allow user to create all variant adjacent data by just visiting one view (when user is creating the product) and just clicking the create button